### PR TITLE
Add Sink support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /Cargo.lock
 /target
+.idea/
+*.iml

--- a/examples/sink.rs
+++ b/examples/sink.rs
@@ -1,0 +1,19 @@
+extern crate aubio;
+
+use std::env;
+
+use aubio::source::Source;
+use aubio::sink::Sink;
+
+fn main() {
+    const HOP_SIZE: usize = 512;
+    const SAMPLE_RATE: usize = 44100;
+    let argv = env::args().collect::<Vec<_>>();
+
+    let mut source = Source::open(&argv[1], SAMPLE_RATE, HOP_SIZE).unwrap();
+    let mut sink = Sink::open(&argv[2], SAMPLE_RATE).unwrap();
+
+    while let Some(buf) = source.read() {
+        sink.write(&buf);
+    }
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -6,6 +6,7 @@ use super::types;
 
 pub enum Source {}
 pub enum Tempo {}
+pub enum Sink {}
 
 #[repr(C)]
 pub struct FVecMut<'a> {
@@ -58,4 +59,9 @@ extern "C" {
     pub fn aubio_tempo_do(tempo: *mut Tempo, imput: *const FVec, tempo: *mut FVecMut);
     pub fn aubio_tempo_get_bpm(tempo: *const Tempo) -> types::Sample;
     pub fn aubio_tempo_get_last_ms(tempo: *const Tempo) -> types::Sample;
+
+    pub fn new_aubio_sink(uri: *const c_char, sample_rate: c_uint) -> *mut Sink;
+    pub fn del_aubio_sink(sink: *mut Sink);
+    pub fn aubio_sink_get_samplerate(sink: *const Sink) -> c_uint;
+    pub fn aubio_sink_do(sink: *mut Sink, write_data: *const FVec, write: c_uint);
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -7,6 +7,7 @@ use super::types;
 pub enum Source {}
 pub enum Tempo {}
 pub enum Sink {}
+pub enum Onset {}
 
 #[repr(C)]
 pub struct FVecMut<'a> {
@@ -64,4 +65,9 @@ extern "C" {
     pub fn del_aubio_sink(sink: *mut Sink);
     pub fn aubio_sink_get_samplerate(sink: *const Sink) -> c_uint;
     pub fn aubio_sink_do(sink: *mut Sink, write_data: *const FVec, write: c_uint);
+
+    pub fn new_aubio_onset(method: *const c_char, buf_size: c_uint, hop_size: c_uint, sample_rate: c_uint) -> *mut Onset;
+    pub fn del_aubio_onset(onset: *mut Onset);
+    pub fn aubio_onset_do(onset: *mut Onset, input: *const FVec, onset: *mut FVecMut);
+    pub fn aubio_onset_get_last(onset: *mut Onset) -> c_uint;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod source;
 pub mod types;
 pub mod tempo;
 pub mod sink;
+pub mod onset;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ mod ffi;
 pub mod source;
 pub mod types;
 pub mod tempo;
+pub mod sink;

--- a/src/onset.rs
+++ b/src/onset.rs
@@ -1,0 +1,60 @@
+use std::ptr;
+
+use super::ffi::{self, c_char};
+use super::types;
+
+#[derive(Debug)]
+pub struct Onset {
+    ptr: *mut ffi::Onset,
+    hop_size: usize,
+}
+
+unsafe impl Send for Onset {}
+
+// all non-Sync methods take &mut self:
+unsafe impl Sync for Onset {}
+
+impl Onset {
+    pub fn new(buffer_size: usize, hop_size: usize, sample_rate: usize) -> Result<Self, ()> {
+        const DEFAULT: *const c_char = b"default\0" as *const u8 as *const i8;
+
+        let ptr = unsafe {
+            ffi::new_aubio_onset(DEFAULT,
+                ffi::uint(buffer_size),
+                ffi::uint(hop_size),
+                ffi::uint(sample_rate))
+        };
+
+        if ptr == ptr::null_mut() {
+            Err(())
+        } else {
+            Ok(Onset { ptr, hop_size })
+        }
+    }
+
+    pub fn get_last(&mut self) -> f32 {
+        let last = unsafe { ffi::aubio_onset_get_last(self.ptr) };
+        last as f32
+    }
+
+    /// input_buffer length must equal hop_size!
+    pub fn execute(&mut self, input_buffer: &[types::Sample]) {
+        assert!(input_buffer.len() == self.hop_size);
+
+        let mut onset = vec![0f32; 2];
+        let mut onset_fvec = ffi::fvec_mut(&mut onset);
+        let input_fvec = ffi::fvec(input_buffer);
+
+        unsafe {
+            ffi::aubio_onset_do(self.ptr,
+                &input_fvec as *const ffi::FVec,
+                &mut onset_fvec as *mut ffi::FVecMut);
+        }
+    }
+}
+
+impl Drop for Onset {
+    fn drop(&mut self) {
+        unsafe { ffi::del_aubio_onset(self.ptr) }
+    }
+}

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,0 +1,58 @@
+use std::ffi::{CString, NulError};
+use std::ptr;
+
+use super::ffi::{self, c_uint};
+use super::types;
+
+#[derive(Debug)]
+pub struct Sink {
+    ptr: *mut ffi::Sink
+}
+
+unsafe impl Send for Sink {}
+
+// all non-Sync methods take &mut self:
+unsafe impl Sync for Sink {}
+
+#[derive(Debug)]
+pub enum SinkError {
+    NulInUri(NulError),
+    BadSink,
+}
+
+impl Sink {
+    pub fn open(uri: &str, sample_rate: usize) -> Result<Self, SinkError> {
+        let uri_cstr = CString::new(uri).map_err(SinkError::NulInUri)?;
+
+        let ptr = unsafe {
+            ffi::new_aubio_sink(uri_cstr.as_ptr(),
+                                ffi::uint(sample_rate))
+        };
+
+        if ptr == ptr::null_mut() {
+            Err(SinkError::BadSink)
+        } else {
+            Ok(Sink { ptr })
+        }
+    }
+
+    pub fn write(&mut self, write_data: &[types::Sample]) {
+        unsafe {
+            let input_fvec = ffi::fvec(write_data);
+            let write: c_uint = write_data.len() as u32;
+            {
+                ffi::aubio_sink_do(self.ptr, &input_fvec as *const ffi::FVec, write);
+            }
+        }
+    }
+
+    pub fn sample_rate(&self) -> usize {
+        unsafe { ffi::aubio_sink_get_samplerate(self.ptr) as usize }
+    }
+}
+
+impl Drop for Sink {
+    fn drop(&mut self) {
+        unsafe { ffi::del_aubio_sink(self.ptr) }
+    }
+}


### PR DESCRIPTION
First up, thanks for this library. 
Having never really programmed in rust (or c for that matter), I was very surprised it "just worked", and have already had great success using the [alsa-rs](https://github.com/diwic/alsa-rs) library as a source! 

I've added an implementation for `Sink`, this follows a similar pattern for how the `Source` is implemented.

I've included a basic example too:
`cargo run --example sink in.wav out.wav`